### PR TITLE
Remove old analytics code

### DIFF
--- a/resources/sass/util/shadow.sass
+++ b/resources/sass/util/shadow.sass
@@ -14,7 +14,7 @@
   box-shadow: none
 
 .text-shadow
-  text-shadow: 0 2px 4px rgba(0,0,0,0.10)
+  text-shadow: 0px 2px 5px rgba(0,0,0,0.25)
 
 .text-shadow-md
   text-shadow: 0 4px 8px rgba(0,0,0,0.12), 0 2px 4px rgba(0,0,0,0.08)

--- a/templates/layout.php
+++ b/templates/layout.php
@@ -48,7 +48,7 @@ use CascadiaPHP\Site\SEO\SEOTools;
 
 <?= $this->section('header') ?>
 
-<!--<amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-K3ZSMBF&gtm.url=<?= urlencode($this->formUri($active ?? '')) ?>" data-credentials="include"></amp-analytics>-->
+<amp-analytics config="https://www.googletagmanager.com/amp.json?id=GTM-K3ZSMBF&gtm.url=SOURCE_URL" data-credentials="include"></amp-analytics>
 <amp-analytics type="googleanalytics">
     <script type="application/json">
         {
@@ -69,7 +69,6 @@ use CascadiaPHP\Site\SEO\SEOTools;
 $this->insert('structure/sidebar', [
     'active' => $active ?? ''
 ]);
-
 ?>
 
 <div class="main-structure mx-auto relative flex flex-column justify-between shadow">

--- a/templates/structure/footer.php
+++ b/templates/structure/footer.php
@@ -9,7 +9,7 @@ $commit = $this->e(substr(getenv('VERSION'), 0, 8));
             <a href="/legal/terms">Terms &amp; Conditions</a>
             <a href="/legal/coc">Code of Conduct</a>
         </div>
-        <div class="flex flex-column justify-center">
+        <div class="flex flex-column justify-center white">
             <div>
                 <span class="nowrap text-shadow">&copy; <?= $this->e(date('Y')); ?></span> <span class="nowrap text-shadow">Cascadia PHP</span>
             </div>


### PR DESCRIPTION
We used to use analytics instead of google tag manager. Now with GTM we don't need to be so explicit about our triggers.